### PR TITLE
Require cc-cmds to load the definition of c-indent-line-or-region

### DIFF
--- a/kotlin-mode.el
+++ b/kotlin-mode.el
@@ -26,6 +26,7 @@
 ;;; Code:
 
 (require 'rx)
+(require 'cc-cmds)
 
 (defgroup kotlin nil
   "A Kotlin major mode."


### PR DESCRIPTION
In GNU emacs 26.0, c-indent-line-or-region isn't autoloaded.