### PR TITLE
Switch from using a Bash script to using Make for the tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: generic
+sudo: false
+before_install:
+  - curl -fsSkL https://gist.github.com/rejeep/ebcd57c3af83b049833b/raw > x.sh && source ./x.sh
+  - evm install $EVM_EMACS --use --skip
+  - cask
+env:
+  - EVM_EMACS=emacs-25.1-travis
+  - EVM_EMACS=emacs-git-snapshot-travis
+script:
+  - emacs --version
+  - cask exec ert-runner
+
+notifications:
+  email: false
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - env: EVM_EMACS=emacs-git-snapshot-travis

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,0 @@
-all: test
-
-test:
-	cask exec emacs -batch -l ert -l test/kotlin-mode-test.el -f ert-run-tests-batch-and-exit
-
-.PHONY: all test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+all: test
+
+test:
+	cask exec emacs -batch -l ert -l test/kotlin-mode-test.el -f ert-run-tests-batch-and-exit
+
+.PHONY: all test

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-cd ../
-emacs -batch -l ert -l test/kotlin-mode-test.el -f ert-run-tests-batch-and-exit
-cd test


### PR DESCRIPTION
I propose that we remove the shell script and employ a Makefile to run the tests.

Actually, it seems `cask exec ert-runner` is as good a way of running the tests.
