### PR TITLE
Fix highlighting escaped identifiers in interpolations

### DIFF
--- a/kotlin-mode.el
+++ b/kotlin-mode.el
@@ -294,10 +294,12 @@
     (remove-text-properties start end '(kotlin-property--interpolation))
     (funcall
      (syntax-propertize-rules
-      ((let ((identifier '(any alnum " !%&()*+-./:<>?[]^_|~")))
+      ((let ((identifier '(or
+                           (and alpha (* alnum))
+                           (and "`" (+ (not (any "`\n"))) "`"))))
          (rx-to-string
-          `(or (group "${" (* ,identifier) "}")
-               (group "$" (+ ,identifier)))))
+          `(or (group "${" ,identifier "}")
+               (group "$" ,identifier))))
        (0 (ignore (kotlin-mode--syntax-propertize-interpolation)))))
      start end)))
 

--- a/test/sample.kt
+++ b/test/sample.kt
@@ -711,3 +711,10 @@ class Test {
 
     }
 }
+
+fun itpl() {
+    print("$foo/bar");
+    print("$`weird$! identifier`bar");
+    print("${foo}bar");
+    print("${`weird$! identifier`}bar");
+}


### PR DESCRIPTION
Reference: https://discuss.kotlinlang.org/t/more-characters-allowed-for-identifiers-than-grammar-specifies-what-is-supported/2359/6