### PR TITLE
Set adaptive-fill-regexp to comment-start-skip

### DIFF
--- a/kotlin-mode.el
+++ b/kotlin-mode.el
@@ -405,6 +405,7 @@
   (set (make-local-variable 'comment-start-skip) "\\(//+\\|/\\*+\\)\\s *")
   (set (make-local-variable 'comment-end) "")
   (set (make-local-variable 'indent-line-function) 'kotlin-mode--indent-line)
+  (setq-local adaptive-fill-regexp comment-start-skip)
 
   :group 'kotlin
   :syntax-table kotlin-mode-syntax-table)


### PR DESCRIPTION
Without this, calling (beginning-of-line-text) on a comment like

// This is a comment.

will bring the cursor to:

[/]/ This is a comment.

Whereas the expected result of calling (beginning-of-line-text) would be

// [T]his is a comment.

See also:  https://github.com/swift-emacs/swift-mode/blob/master/swift-mode.el#L189