### PR TITLE
1x indent inside parenthesis

### DIFF
--- a/kotlin-mode.el
+++ b/kotlin-mode.el
@@ -358,7 +358,7 @@
             ((looking-at "^[ \t]*)") ; line starts with )
              (save-excursion
                (kotlin-mode--prev-line)
-               (setq cur-indent (- (current-indentation) (* 2 kotlin-tab-width))))
+               (setq cur-indent (- (current-indentation) kotlin-tab-width)))
              (if (< cur-indent 0)
                  (setq cur-indent 0)))
 
@@ -379,7 +379,7 @@
                         (setq not-indented nil))
 
                        ((looking-at ".*([ \t]*$") ; line ends with (
-                        (setq cur-indent (+ (current-indentation) (* 2 kotlin-tab-width)))
+                        (setq cur-indent (+ (current-indentation) kotlin-tab-width))
                         (setq not-indented nil))
 
                        ((looking-at "^[ \t]*).*$") ; line starts with )


### PR DESCRIPTION
Simply removed 2x factor. Maybe we should use customisable variable here, e.g. kotlin-args-indent-factor.