### PR TITLE
Fix syntax highlighting of star-projected types

### DIFF
--- a/kotlin-mode.el
+++ b/kotlin-mode.el
@@ -214,7 +214,7 @@
 
     ;; Types
     (,(rx-to-string
-      `(and bow upper (group (* (or word "<" ">" "." "?" "!"))))
+      `(and bow upper (group (* (or word "<" ">" "." "?" "!" "*"))))
       t)
      0 font-lock-type-face)
 


### PR DESCRIPTION
Previously, when encountering a star-projected type (like `List<*>`),
kotlin-mode would highlight it only to the opening `<`. This commit adds `*` to
the characters that can appear in a type so that it correctly highlights
through the closing `>`.

Tested by creating a file `test.kt` with the following contents:
```
val x: List<*> = f()
```
Prior to this commit, this would only highlight through the opening `<`, now it
highlights through the closing `>`.

(I'm happy to add an automated test for this if you can point me to how; I just have no idea how to make assertions about font-lock highlighting.)