### PR TITLE
Indentation Improvements

### DIFF
--- a/kotlin-mode.el
+++ b/kotlin-mode.el
@@ -172,7 +172,7 @@
     "when" "is" "in" "as" "return"))
 
 (defconst kotlin-mode--context-variables-keywords
-  '("this" "super"))
+  '("field" "it" "this" "super"))
 
 (defvar kotlin-mode--keywords
   (append kotlin-mode--misc-keywords
@@ -192,7 +192,7 @@
     "annotation" "internal" "const" "in" "out")) ;; "in" "out"
 
 (defconst kotlin-mode--property-keywords
-  '("by")) ;; "by" "get" "set"
+  '("by" "get" "set")) ;; "by" "get" "set"
 
 (defconst kotlin-mode--initializer-keywords
   '("init" "constructor"))
@@ -256,11 +256,11 @@
 
     ;; Properties
     ;; by/get/set are valid identifiers being used as variable
-    ;; TODO: Highlight keywords in the property declaration statement
-    ;; (,(rx-to-string
-    ;;    `(and bow (group (or ,@kotlin-mode--property-keywords)) eow)
-    ;;    t)
-    ;;  1 font-lock-keyword-face)
+    ;; TODO: Highlight only within the property declaration statement
+    (,(rx-to-string
+       `(and bow (group (or ,@kotlin-mode--property-keywords)) eow)
+       t)
+     1 font-lock-keyword-face)
 
     ;; Constructor/Initializer blocks
     (,(rx-to-string
@@ -344,7 +344,7 @@
 (defun kotlin-mode--line-continuation()
   "Return whether this line continues a statement in the previous line"
   (or
-   (kotlin-mode--line-begins "\\([\.=:]\\|->\\)")
+   (kotlin-mode--line-begins "\\([\.=:]\\|->\\|[sg]et\\b\\)")
    (save-excursion
      (kotlin-mode--prev-line)
      (kotlin-mode--line-ends "\\([=:]\\|->\\)"))))

--- a/kotlin-mode.el
+++ b/kotlin-mode.el
@@ -28,6 +28,8 @@
 (require 'comint)
 (require 'rx)
 (require 'cc-cmds)
+(require 'cl)
+(require 'eieio)
 
 (defgroup kotlin nil
   "A Kotlin major mode."

--- a/kotlin-mode.el
+++ b/kotlin-mode.el
@@ -128,7 +128,6 @@
     (define-key map (kbd "C-c C-r") 'kotlin-send-region)
     (define-key map (kbd "C-c C-c") 'kotlin-send-block)
     (define-key map (kbd "C-c C-b") 'kotlin-send-buffer)
-    (define-key map (kbd "<tab>") 'c-indent-line-or-region)
     map)
   "Keymap for kotlin-mode")
 

--- a/test/kotlin-mode-test.el
+++ b/test/kotlin-mode-test.el
@@ -47,28 +47,58 @@ return a + b
     return a + b
 }")))))
 
-;; (ert-deftest kotlin-mode--chained-methods ()
-;;   (with-temp-buffer
-;;     (let ((text "names.filter { it.empty }
-;; .sortedBy { it }
-;; .map { it.toUpperCase() }
-;; .forEach { print(it) }"))
+(ert-deftest kotlin-mode--chained-methods ()
+  (with-temp-buffer
+    (let ((text "names.filter { it.empty }
+.sortedBy { it }
+.map { it.toUpperCase() }
+.forEach { print(it) }"))
 
-;;       (insert text)
-;;       (beginning-of-buffer)
+      (insert text)
+      (beginning-of-buffer)
 
-;;       (kotlin-mode--indent-line)
+      (kotlin-mode--indent-line)
 
-;;       (next-line)
-;;       (kotlin-mode--indent-line)
+      (next-line)
+      (kotlin-mode--indent-line)
 
-;;       (next-line)
-;;       (kotlin-mode--indent-line)
+      (next-line)
+      (kotlin-mode--indent-line)
 
-;;       (next-line)
-;;       (kotlin-mode--indent-line)
+      (next-line)
+      (kotlin-mode--indent-line)
 
-;;       (should (equal (buffer-string) "names.filter { it.empty }
-;; 	.sortedBy { it }
-;; 	.map { it.toUpperCase() }
-;; 	.forEach { print(it) }")))))
+      (should (equal (buffer-string) "names.filter { it.empty }
+    .sortedBy { it }
+    .map { it.toUpperCase() }
+    .forEach { print(it) }")))))
+
+(defun next-non-empty-line ()
+  "Moves to the next non-empty line"
+  (forward-line)
+  (while (and (looking-at "^[ \t]*$") (not (eobp)))
+    (forward-line)))
+
+(ert-deftest kotlin-mode--sample-test ()
+  (with-temp-buffer
+      (insert-file-contents "sample.kt")
+      (beginning-of-buffer)
+      (while (not (eobp))
+        (let ((expected-line (thing-at-point 'line)))
+
+          ;; Remove existing indentation
+          (beginning-of-line)
+          (delete-region (point) (progn (skip-chars-forward " \t") (point)))
+
+          ;; Indent the line
+          (kotlin-mode--indent-line)
+
+          ;; Check that the correct indentation is re-applied
+          (should (equal expected-line (thing-at-point 'line)))
+
+          ;; Go to the next non-empty line
+          (next-non-empty-line)
+          )
+        )
+      )
+  )

--- a/test/kotlin-mode-test.el
+++ b/test/kotlin-mode-test.el
@@ -1,4 +1,8 @@
-(load-file "../kotlin-mode.el")
+;; Tests assume a tab is represented by 4 spaces
+(setq-default indent-tabs-mode nil)
+(setq-default tab-width 4)
+
+(load-file "kotlin-mode.el")
 
 ;(require 'kotlin-mode)
 
@@ -81,7 +85,7 @@ return a + b
 
 (ert-deftest kotlin-mode--sample-test ()
   (with-temp-buffer
-      (insert-file-contents "sample.kt")
+      (insert-file-contents "test/sample.kt")
       (beginning-of-buffer)
       (while (not (eobp))
         (let ((expected-line (thing-at-point 'line)))

--- a/test/kotlin-mode-test.el
+++ b/test/kotlin-mode-test.el
@@ -1,4 +1,4 @@
-(load-file "kotlin-mode.el")
+(load-file "../kotlin-mode.el")
 
 ;(require 'kotlin-mode)
 
@@ -44,7 +44,7 @@ return a + b
 
       (kotlin-mode--indent-line)
       (should (equal (buffer-string) "fun sum(a: Int, b: Int): Int {
-	return a + b
+    return a + b
 }")))))
 
 ;; (ert-deftest kotlin-mode--chained-methods ()

--- a/test/sample.kt
+++ b/test/sample.kt
@@ -105,14 +105,14 @@ if (text in names) // names.contains(text) is called
 print("Yes")
 
 names.filter { it.startsWith("A") }
-        .sortedBy { it }
-        .map { it.toUpperCase() }
-        .forEach { print(it) }
+    .sortedBy { it }
+    .map { it.toUpperCase() }
+    .forEach { print(it) }
 
 fun f() {
     things.f()
-            .g()
-            .h()
+        .g()
+        .h()
 }
 
 data class Customer(val name: String, val email: String)
@@ -191,18 +191,19 @@ class Turtle {
 }
 
 val myTurtle = Turtle()
-with(myTurtle) { //draw a 100 pix square
-penDown()
-for(i in 1..4) {
-    forward(100.0)
-    turn(90.0)
-}
-penUp()
+with(myTurtle) {
+    //draw a 100 pix square
+    penDown()
+    for(i in 1..4) {
+        forward(100.0)
+        turn(90.0)
+    }
+    penUp()
 }
 
 val stream = Files.newInputStream(Paths.get("/some/file.txt"))
-stream.buffered().reader().use { reader ->
-    println(reader.readText())
+stream.buffered().reader().use {
+    reader -> println(reader.readText())
 }
 
 inline fun <reified T: Any> Gson.fromJson(json): T = this.fromJson(json, T::class.java)
@@ -718,3 +719,4 @@ fun itpl() {
     print("${foo}bar");
     print("${`weird$! identifier`}bar");
 }
+

--- a/test/sample.kt
+++ b/test/sample.kt
@@ -6,9 +6,9 @@ import bar.Bar as bBar
 
 // a single line comment
 
-/*
-* a multiline comment
-*/
+/**
+ * a multiline comment
+ */
 
 fun sum(a: Int, b: Int): Int {
     return a + b

--- a/test/sample.kt
+++ b/test/sample.kt
@@ -10,6 +10,11 @@ import bar.Bar as bBar
  * a multiline comment
  */
 
+/****************************************************************
+ Multiline comment
+ without leading "*"
+****************************************************************/
+
 fun sum(a: Int, b: Int): Int {
     return a + b
 }
@@ -21,7 +26,16 @@ fun printSum(a: Int, b: Int): Unit {
 }
 
 fun printSum(a: Int, b: Int) {
-    print(a + b)
+    val veryLongResultVariableName: Int
+        = (a + b)
+    print(veryLongResultVariableName)
+}
+
+fun functionMultiLineArgs(first: Int,
+                          second: Int,
+                          third: Int,
+                          fourth: Int) {
+    print("(${first}, ${second}, ${third}, ${fourth})")
 }
 
 val a: Int = 1
@@ -288,7 +302,9 @@ class Derived() : Base() {
     override fun v() {}
 }
 
-open class AnotherDerived() : Base() {
+open class AnotherDerived()
+    : Base() {
+
     final override fun v() {}
 }
 
@@ -564,14 +580,15 @@ enum class ProtocolState {
     abstract fun signal(): ProtocolState
 }
 
-window.addMouseListener(object : MouseAdapter() {
-    override fun mouseClicked(e: MouseEvent) {
-        // ...
-    }
+window.addMouseListener(
+    object : MouseAdapter() {
+        override fun mouseClicked(e: MouseEvent) {
+            // ...
+        }
 
-    override fun mouseEntered(e: MouseEvent) {
-        // ...
-    }
+        override fun mouseEntered(e: MouseEvent) {
+            // ...
+        }
 })
 
 val adHoc = object {
@@ -584,14 +601,15 @@ fun countClicks(window: JComponent) {
     var clickCount = 0
     var enterCount = 0
 
-    window.addMouseListener(object : MouseAdapter() {
-        override fun mouseClicked(e: MouseEvent) {
-            clickCount++
-        }
+    window.addMouseListener(
+        object : MouseAdapter() {
+            override fun mouseClicked(e: MouseEvent) {
+                clickCount++
+            }
 
-        override fun mouseEntered(e: MouseEvent) {
-            enterCount++
-        }
+            override fun mouseEntered(e: MouseEvent) {
+                enterCount++
+            }
     })
     // ...
 }
@@ -635,7 +653,7 @@ fun <T> asList(vararg ts: T): List<T> {
 }
 
 tailrec fun findFixPoint(x: Double = 1.0): Double
-= if (x == Math.cos(x)) x else findFixPoint(Math.cos(x))
+    = if (x == Math.cos(x)) x else findFixPoint(Math.cos(x))
 
 fun <T> lock(lock: Lock, body: () -> T): T {
     lock.lock()

--- a/test/sample.kt
+++ b/test/sample.kt
@@ -356,10 +356,10 @@ fun eval(expr: Expr): Double = when(expr) {
 }
 
 var stringRepresentation: String
-get() = this.toString()
-set(value) {
-    setDataFromString(value) // parses the string and assigns values to other properties
-}
+    get() = this.toString()
+    set(value) {
+        setDataFromString(value) // parses the string and assigns values to other properties
+    }
 
 var setterVisibility: String = "abc"
 private set // the setter is private and has the default implementation
@@ -368,13 +368,13 @@ var setterWithAnnotation: Any? = null
 @Inject set // annotate the setter with Inject
 
 var counter = 0 // the initializer value is written directly to the backing field
-set(value) {
-    if (value >= 0)
-    field = value
-}
+    set(value) {
+        if (value >= 0)
+        field = value
+    }
 
 val isEmpty: Boolean
-get() = this.size == 0
+    get() = this.size == 0
 
 const val SUBSYSTEM_DEPRECATED: String = "This subsystem is deprecated"
 
@@ -409,7 +409,7 @@ interface MyInterface {
     val property: Int // abstract
 
     val propertyWithImplementation: String
-    get() = "foo"
+        get() = "foo"
 
     fun foo() {
         print(property)
@@ -479,7 +479,7 @@ fun Any?.toString(): String {
 }
 
 val <T> List<T>.lastIndex: Int
-get() = size - 1
+    get() = size - 1
 
 class MyClass {
     companion object { }  // will be called "Companion"

--- a/test/sample.kt
+++ b/test/sample.kt
@@ -303,8 +303,8 @@ class Derived() : Base() {
 }
 
 open class AnotherDerived()
-    : Base() {
-
+    : Base()
+{
     final override fun v() {}
 }
 
@@ -327,7 +327,7 @@ interface B {
 }
 
 class C() : A(), B {
-    // The compiler requires f() to be overridden:
+    // The compiler requires f() to be overridden
     override fun f() {
         super<A>.f() // call to A.f()
         super<B>.f() // call to B.f()
@@ -726,8 +726,16 @@ inline fun <reified T> TreeNode.findParentOfType(): T? {
 }
 
 class Test {
-    fun f() {
-
+    fun tryAdd(a: Int?, b: Int?) : Int? {
+        var result: Int? = null
+        a?.let {
+            lhs ->
+                b?.let {
+                    rhs ->
+                        result = lhs + rhs
+                }
+        }
+        return result
     }
 }
 


### PR DESCRIPTION
# Main change
Indentation improvements, mainly based on levels of brackets, plus "continuation indentation" where certain symbols begin/end lines.  The results of these changes are best understood by looking at the changes/additions to `test/sample.kt`.  I've extended `test/kotlin-mode-test.el` with a test that verifies the accuracy of this file by indenting each line and checking that nothing changes.

# Extra
- Removed override of `<tab>` key mapping, which was preventing region indentation working for me.
- Added highlighting of `get`, `set`, `field` and `it` keywords.  (I realise some of this had been deliberately commented out, so happy to revert if it's still work-in-progress)