### PR TITLE
Fix warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,9 @@ before_install:
   - evm install $EVM_EMACS --use --skip
   - cask
 env:
-  # https://github.com/Emacs-Kotlin-Mode-Maintainers/kotlin-mode/issues/46
-  #- EVM_EMACS=emacs-24.1-travis
-  #- EVM_EMACS=emacs-24.2-travis
-  #- EVM_EMACS=emacs-24.3-travis
-  #- EVM_EMACS=emacs-24.4-travis
-  #- EVM_EMACS=emacs-24.5-travis
+  - EVM_EMACS=emacs-24.3-travis
+  - EVM_EMACS=emacs-24.4-travis
+  - EVM_EMACS=emacs-24.5-travis
   - EVM_EMACS=emacs-25.1-travis
   - EVM_EMACS=emacs-25.2-travis
   - EVM_EMACS=emacs-25.3-travis

--- a/kotlin-mode.el
+++ b/kotlin-mode.el
@@ -28,7 +28,7 @@
 (require 'comint)
 (require 'rx)
 (require 'cc-cmds)
-(require 'cl)
+(require 'cl-lib)
 (require 'eieio)
 
 (require 'kotlin-mode-lexer)

--- a/kotlin-mode.el
+++ b/kotlin-mode.el
@@ -391,8 +391,7 @@
    We scroll backwards until the net-bracket-count is zero, and this point
    determines the desired indentation level for the current line.")
 
-(cl-defmethod kotlin-mode--count-to-line-start
-  ((counter kotlin-mode--bracket-counter))
+(defun kotlin-mode--count-to-line-start (counter)
   "Count the brackets on the current line, starting from the cursor
    position, and working backward, incrementing the count
    +1 for open-brackets, -1 for close-brackets.
@@ -424,15 +423,13 @@
         (kotlin-mode--add-indent counter
                                  (- position (re-search-backward "^"))))))))
 
-(cl-defmethod kotlin-mode--count-leading-close-brackets
-    ((counter kotlin-mode--bracket-counter))
+(defun kotlin-mode--count-leading-close-brackets (counter)
   "Count any close-bracket at the start of the current line."
   (if (looking-at "\\s)")
       (oset counter use-base nil))
   (kotlin-mode--subtract-count counter (skip-syntax-forward ")")))
 
-(cl-defmethod kotlin-mode--count-trailing-open-brackets
-    ((counter kotlin-mode--bracket-counter))
+(defun kotlin-mode--count-trailing-open-brackets (counter)
   "If the bracket count is at zero, and there are open-brackets at the end
    of the line, do not count them, but add a single indentation level."
   (if (= (oref counter count) 0)
@@ -440,19 +437,16 @@
              (kotlin-mode--add-indent counter kotlin-tab-width)
              (oset counter use-base nil)))))
 
-(cl-defmethod kotlin-mode--add-count
-  ((counter kotlin-mode--bracket-counter) val)
+(defun kotlin-mode--add-count (counter val)
   (cl-incf (oref counter count) val))
 
-(cl-defmethod kotlin-mode--subtract-count
-  ((counter kotlin-mode--bracket-counter) val)
+(defun kotlin-mode--subtract-count (counter val)
   (cl-decf (oref counter count) val))
 
-(cl-defmethod kotlin-mode--add-indent
-  ((counter kotlin-mode--bracket-counter) val)
+(defun kotlin-mode--add-indent (counter val)
   (cl-incf (oref counter indent) val))
 
-(cl-defmethod kotlin-mode--finished ((counter kotlin-mode--bracket-counter))
+(defun kotlin-mode--finished (counter)
   (oref counter finished))
 
 (defun kotlin-mode--in-comment-block ()
@@ -484,7 +478,7 @@
       (kotlin-mode--beginning-of-buffer-indent)
     (let ((cur-indent 0))
       ;; Find bracket-based indentation first
-      (let ((bracket-counter (kotlin-mode--bracket-counter)))
+      (let ((bracket-counter (make-instance 'kotlin-mode--bracket-counter)))
         (save-excursion
           (skip-syntax-forward "-")
           (kotlin-mode--count-leading-close-brackets bracket-counter))

--- a/test/kotlin-mode-test.el
+++ b/test/kotlin-mode-test.el
@@ -9,7 +9,7 @@ import foo.Bar
 import bar.Bar as bBar
 "))
       (insert text)
-      (beginning-of-buffer)
+      (goto-char (point-min))
       (kotlin-mode)
       (setq-local indent-tabs-mode nil)
       (setq-local tab-width 4)
@@ -19,19 +19,19 @@ import bar.Bar as bBar
 
       (should (equal text (buffer-string)))
 
-      (next-line)
+      (forward-line)
       (kotlin-mode--indent-line)
       (should (equal text (buffer-string)))
 
-      (next-line)
+      (forward-line)
       (kotlin-mode--indent-line)
       (should (equal text (buffer-string)))
 
-      (next-line)
+      (forward-line)
       (kotlin-mode--indent-line)
       (should (equal text (buffer-string)))
 
-      (next-line)
+      (forward-line)
       (kotlin-mode--indent-line)
       (should (equal text (buffer-string))))))
 
@@ -42,12 +42,12 @@ return a + b
 }"))
 
       (insert text)
-      (beginning-of-buffer)
+      (goto-char (point-min))
       (kotlin-mode)
       (setq-local indent-tabs-mode nil)
       (setq-local tab-width 4)
       (setq-local kotlin-tab-width 4)
-      (next-line)
+      (forward-line)
 
       (kotlin-mode--indent-line)
       (should (equal (buffer-string) "fun sum(a: Int, b: Int): Int {
@@ -62,7 +62,7 @@ return a + b
 .forEach { print(it) }"))
 
       (insert text)
-      (beginning-of-buffer)
+      (goto-char (point-min))
       (kotlin-mode)
       (setq-local indent-tabs-mode nil)
       (setq-local tab-width 4)
@@ -70,13 +70,13 @@ return a + b
 
       (kotlin-mode--indent-line)
 
-      (next-line)
+      (forward-line)
       (kotlin-mode--indent-line)
 
-      (next-line)
+      (forward-line)
       (kotlin-mode--indent-line)
 
-      (next-line)
+      (forward-line)
       (kotlin-mode--indent-line)
 
       (should (equal (buffer-string) "names.filter { it.empty }
@@ -93,7 +93,7 @@ return a + b
 (ert-deftest kotlin-mode--sample-test ()
   (with-temp-buffer
     (insert-file-contents "test/sample.kt")
-    (beginning-of-buffer)
+    (goto-char (point-min))
     (kotlin-mode)
     (setq-local indent-tabs-mode nil)
     (setq-local tab-width 4)

--- a/test/kotlin-mode-test.el
+++ b/test/kotlin-mode-test.el
@@ -1,7 +1,3 @@
-;; Tests assume a tab is represented by 4 spaces
-(setq-default indent-tabs-mode nil)
-(setq-default tab-width 4)
-
 (require 'kotlin-mode)
 
 (ert-deftest kotlin-mode--top-level-indent-test ()
@@ -14,6 +10,11 @@ import bar.Bar as bBar
 "))
       (insert text)
       (beginning-of-buffer)
+      (kotlin-mode)
+      (setq-local indent-tabs-mode nil)
+      (setq-local tab-width 4)
+      (setq-local kotlin-tab-width 4)
+
       (kotlin-mode--indent-line)
 
       (should (equal text (buffer-string)))
@@ -42,6 +43,10 @@ return a + b
 
       (insert text)
       (beginning-of-buffer)
+      (kotlin-mode)
+      (setq-local indent-tabs-mode nil)
+      (setq-local tab-width 4)
+      (setq-local kotlin-tab-width 4)
       (next-line)
 
       (kotlin-mode--indent-line)
@@ -58,6 +63,10 @@ return a + b
 
       (insert text)
       (beginning-of-buffer)
+      (kotlin-mode)
+      (setq-local indent-tabs-mode nil)
+      (setq-local tab-width 4)
+      (setq-local kotlin-tab-width 4)
 
       (kotlin-mode--indent-line)
 
@@ -83,24 +92,24 @@ return a + b
 
 (ert-deftest kotlin-mode--sample-test ()
   (with-temp-buffer
-      (insert-file-contents "test/sample.kt")
-      (beginning-of-buffer)
-      (while (not (eobp))
-        (let ((expected-line (thing-at-point 'line)))
+    (insert-file-contents "test/sample.kt")
+    (beginning-of-buffer)
+    (kotlin-mode)
+    (setq-local indent-tabs-mode nil)
+    (setq-local tab-width 4)
+    (setq-local kotlin-tab-width 4)
+    (while (not (eobp))
+      (let ((expected-line (thing-at-point 'line)))
 
-          ;; Remove existing indentation
-          (beginning-of-line)
-          (delete-region (point) (progn (skip-chars-forward " \t") (point)))
+        ;; Remove existing indentation
+        (beginning-of-line)
+        (delete-region (point) (progn (skip-chars-forward " \t") (point)))
 
-          ;; Indent the line
-          (kotlin-mode--indent-line)
+        ;; Indent the line
+        (kotlin-mode--indent-line)
 
-          ;; Check that the correct indentation is re-applied
-          (should (equal expected-line (thing-at-point 'line)))
+        ;; Check that the correct indentation is re-applied
+        (should (equal expected-line (thing-at-point 'line)))
 
-          ;; Go to the next non-empty line
-          (next-non-empty-line)
-          )
-        )
-      )
-  )
+        ;; Go to the next non-empty line
+        (next-non-empty-line)))))


### PR DESCRIPTION
Fix warnings emitted from `batch-byte-compile`:

```bash
emacs --batch -q \
  --eval "(add-to-list 'load-path \""$(readlink -f .)"\")" \
  --eval "(add-to-list 'load-path \""$(readlink -f .)"/test\")" \
  -f batch-byte-compile *.el test/*.el
```

This PR contains commits from #48.
