### PR TITLE
Fix indentation involving comment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,9 @@ before_install:
   - evm install $EVM_EMACS --use --skip
   - cask
 env:
-  # https://github.com/Emacs-Kotlin-Mode-Maintainers/kotlin-mode/issues/46
-  #- EVM_EMACS=emacs-24.1-travis
-  #- EVM_EMACS=emacs-24.2-travis
-  #- EVM_EMACS=emacs-24.3-travis
-  #- EVM_EMACS=emacs-24.4-travis
-  #- EVM_EMACS=emacs-24.5-travis
+  - EVM_EMACS=emacs-24.3-travis
+  - EVM_EMACS=emacs-24.4-travis
+  - EVM_EMACS=emacs-24.5-travis
   - EVM_EMACS=emacs-25.1-travis
   - EVM_EMACS=emacs-25.2-travis
   - EVM_EMACS=emacs-25.3-travis

--- a/kotlin-mode.el
+++ b/kotlin-mode.el
@@ -148,8 +148,9 @@
 
     ;; b-style comment
     (modify-syntax-entry ?/ ". 124b" st)
-    (modify-syntax-entry ?* ". 23" st)
+    (modify-syntax-entry ?* ". 23n" st)
     (modify-syntax-entry ?\n "> b" st)
+    (modify-syntax-entry ?\r "> b" st)
     st))
 
 
@@ -537,20 +538,23 @@ fun foo() {
    of the following format:
    /**
     * Description here
-    */ "
+    */"
   (save-excursion
     (let ((in-comment-block nil)
-          (keep-going (not (kotlin-mode--line-ends "\\*\\*/"))))
+          (keep-going (and
+                       (not (kotlin-mode--line-begins "\\*\\*+/"))
+                       (not (kotlin-mode--line-begins "/\\*"))
+                       (nth 4 (syntax-ppss)))))
       (while keep-going
         (kotlin-mode--prev-line)
         (cond
+         ((kotlin-mode--line-begins "/\\*")
+          (setq keep-going nil)
+          (setq in-comment-block t))
          ((bobp)
           (setq keep-going nil))
          ((kotlin-mode--line-contains "\\*/")
-          (setq keep-going nil))
-         ((kotlin-mode--line-begins "/\\*")
-          (setq keep-going nil)
-          (setq in-comment-block t))))
+          (setq keep-going nil))))
       in-comment-block)))
 
 (defun kotlin-mode--indent-line ()

--- a/kotlin-mode.el
+++ b/kotlin-mode.el
@@ -28,7 +28,7 @@
 (require 'comint)
 (require 'rx)
 (require 'cc-cmds)
-(require 'cl)
+(require 'cl-lib)
 (require 'eieio)
 
 (require 'kotlin-mode-lexer)

--- a/kotlin-mode.el
+++ b/kotlin-mode.el
@@ -392,10 +392,15 @@
    determines the desired indentation level for the current line.")
 
 (defun kotlin-mode--count-to-line-start (counter)
-  "Count the brackets on the current line, starting from the cursor
-   position, and working backward, incrementing the count
-   +1 for open-brackets, -1 for close-brackets.
-   Return as soon as the overall count exceeds zero."
+  "Count the brackets on the current line, starting from the
+cursor position, and working backward, incrementing the count +1
+for open-brackets, -1 for close-brackets.
+
+Mark the COUNTER finished, set indentation, and return as soon as
+the overall count exceeds zero.  If the counter is zero at the
+beginning of the line, Mark the counter finished and set
+indentation.  If we hit a beginning of line but the counter is
+negative, just return without marking finished."
   (save-excursion
     (while (and (<= (oref counter count) 0) (not (bolp)))
       (backward-char)
@@ -403,39 +408,110 @@
              (cl-incf (oref counter count)))
             ((looking-at "\\s)")
              (cl-decf (oref counter count)))))
+    ;; We are at the beginning of the line, or just before an
+    ;; unmatching open bracket.
     (cond
      ;; If the net-bracket-count is zero, use this indentation
      ((= (oref counter count) 0)
       (oset counter finished t)
       (if (oref counter use-base)
+          ;; Indenting a line that is neither close bracket nor the
+          ;; first element of a block or a list.  Found the previous
+          ;; line.  So align with the previous line, without effect of
+          ;; continued expression at the previous line.
           (kotlin-mode--add-indent counter (kotlin-mode--base-indentation))
+        ;; Indenting close bracket or the first element of a block or
+        ;; a list.  So align with this line, optionally with extra
+        ;; indentation.
         (kotlin-mode--add-indent counter (current-indentation))))
      ;; If we've now counted more open-brackets than close-brackets,
      ;; use the indentation of the content immediately following the
      ;; final open-bracket.
+     ;;
+     ;; Example:
+     ;;
+     ;; Suppose indenting "bar2()" in the following example:
+     ;;
+     ;; foo(  bar1(),
+     ;;       bar2())
+     ;;
+     ;; We are at just before the open bracket of "foo".  So skip the
+     ;; open bracket and spaces, then align "bar2()" with "bar1()".
      ((> (oref counter count) 0)
       (oset counter finished t)
       (forward-char)
       (skip-syntax-forward "(")
       (skip-syntax-forward "-")
-      (let (position)
-        (setq position (point))
-        (kotlin-mode--add-indent counter
-                                 (- position (re-search-backward "^"))))))))
+      (kotlin-mode--add-indent counter (current-column))))))
 
 (defun kotlin-mode--count-leading-close-brackets (counter)
-  "Count any close-bracket at the start of the current line."
-  (if (looking-at "\\s)")
-      (oset counter use-base nil))
-  (kotlin-mode--subtract-count counter (skip-syntax-forward ")")))
+  "Adjust COUNTER when indenting close brackets.
+
+This function should be called at the line being indented.
+
+Example:
+Suppose indenting the closing bracket of \"bar\" in the following example:
+
+fun foo() {
+    bar {
+      baz()
+    } // Indenting here
+}
+
+This function decrements the counter, so that
+`kotlin-mode--count-to-line-start' should not stop at the line
+\"baz()\", but goto the line \"bar {\", so that the close bracket
+aligned with \"bar {\"."
+
+  (save-excursion
+    (skip-syntax-forward "-")
+    (when (looking-at "\\s)")
+      (oset counter use-base nil)
+      (kotlin-mode--subtract-count counter (skip-syntax-forward ")")))))
 
 (defun kotlin-mode--count-trailing-open-brackets (counter)
-  "If the bracket count is at zero, and there are open-brackets at the end
-   of the line, do not count them, but add a single indentation level."
-  (if (= (oref counter count) 0)
-      (cond ((not (= (skip-syntax-backward "(") 0))
-             (kotlin-mode--add-indent counter kotlin-tab-width)
-             (oset counter use-base nil)))))
+  "Adjust COUNTER when indenting the first element of a block or list.
+
+This function should be called before calling
+`kotlin-mode--count-to-line-start', with the point at the end of
+the previous line of the line being indented.
+
+If the bracket count is at zero, and there are open-brackets at
+the end of the line, do not count them, but add a single
+indentation level. If bracket count is at zero, we are not
+indenting close brackets.
+
+Example:
+
+Suppose indenting \"baz()\" in the following example:
+
+fun foo() {
+    bar {
+        baz()
+    }
+}
+
+This function is called with the point at the end of the line
+\"bar {\". This function skips \"{\" backward and add indentation
+amount `kotlin-tab-width', say 4.  Then
+`kotlin-mode--count-to-line-start' seeks to the
+beginning-of-line.  So the final indentation is 8, that is the
+sum of indentation of bar and extra indentation.
+
+On the other hand, when indenting \"baz2()\" in the following
+line, keep cursor and indentation level as is because
+\"bar(baz1(),\" does not end with open brackets.  Then
+`kotlin-mode--count-to-line-start' stops at the close bracket of
+\"bar(\".  So \"baz2()\" is aligned with \"baz1()\".
+
+fun foo() {
+    bar(baz1(),
+        baz2())
+}"
+  (when (and (= (oref counter count) 0)
+             (not (= (skip-syntax-backward "(") 0)))
+    (kotlin-mode--add-indent counter kotlin-tab-width)
+    (oset counter use-base nil)))
 
 (defun kotlin-mode--add-count (counter val)
   (cl-incf (oref counter count) val))
@@ -476,33 +552,33 @@
   (beginning-of-line)
   (if (bobp)
       (kotlin-mode--beginning-of-buffer-indent)
-    (let ((cur-indent 0))
-      ;; Find bracket-based indentation first
-      (let ((bracket-counter (make-instance 'kotlin-mode--bracket-counter)))
-        (save-excursion
-          (skip-syntax-forward "-")
-          (kotlin-mode--count-leading-close-brackets bracket-counter))
-        (save-excursion
-          (progn (kotlin-mode--prev-line) (end-of-line))
-          (kotlin-mode--count-trailing-open-brackets bracket-counter)
-          (kotlin-mode--count-to-line-start bracket-counter)
-          (while (and (not (kotlin-mode--finished bracket-counter))
-                      (not (bobp)))
-            (progn (kotlin-mode--prev-line) (end-of-line))
-            (kotlin-mode--count-to-line-start bracket-counter))
-          (cl-incf cur-indent (oref bracket-counter indent))))
+    (let* ((bracket-counter (make-instance 'kotlin-mode--bracket-counter))
+           ;; Find bracket-based indentation first
+           (cur-indent
+            (progn
+              (kotlin-mode--count-leading-close-brackets bracket-counter)
+              (save-excursion
+                (kotlin-mode--prev-line)
+                (end-of-line)
+                (kotlin-mode--count-trailing-open-brackets bracket-counter)
+                (kotlin-mode--count-to-line-start bracket-counter)
+                (while (and (not (kotlin-mode--finished bracket-counter))
+                            (not (bobp)))
+                  (kotlin-mode--prev-line)
+                  (end-of-line)
+                  (kotlin-mode--count-to-line-start bracket-counter))
+                (oref bracket-counter indent)))))
 
-      (cond ((kotlin-mode--line-continuation)
-             ;; Add extra indentation if the line continues the previous one
-             (cl-incf cur-indent kotlin-tab-width))
-            ((kotlin-mode--in-comment-block)
-             ;; Add one space of extra indentation if inside a comment block
-             (cl-incf cur-indent)))
+      (cond
+       ((kotlin-mode--line-continuation)
+        ;; Add extra indentation if the line continues the previous one
+        (cl-incf cur-indent kotlin-tab-width))
 
-      (if cur-indent
-          (indent-line-to cur-indent)
-        (indent-line-to 0)))))
+       ((kotlin-mode--in-comment-block)
+        ;; Add one space of extra indentation if inside a comment block
+        (cl-incf cur-indent)))
 
+      (indent-line-to cur-indent))))
 
 (defun kotlin-mode--beginning-of-buffer-indent ()
   (indent-line-to 0))

--- a/kotlin-mode.el
+++ b/kotlin-mode.el
@@ -391,8 +391,7 @@
    We scroll backwards until the net-bracket-count is zero, and this point
    determines the desired indentation level for the current line.")
 
-(cl-defmethod kotlin-mode--count-to-line-start
-  ((counter kotlin-mode--bracket-counter))
+(defun kotlin-mode--count-to-line-start (counter)
   "Count the brackets on the current line, starting from the cursor
    position, and working backward, incrementing the count
    +1 for open-brackets, -1 for close-brackets.
@@ -424,15 +423,13 @@
         (kotlin-mode--add-indent counter
                                  (- position (re-search-backward "^"))))))))
 
-(cl-defmethod kotlin-mode--count-leading-close-brackets
-    ((counter kotlin-mode--bracket-counter))
+(defun kotlin-mode--count-leading-close-brackets (counter)
   "Count any close-bracket at the start of the current line."
   (if (looking-at "\\s)")
       (oset counter use-base nil))
   (kotlin-mode--subtract-count counter (skip-syntax-forward ")")))
 
-(cl-defmethod kotlin-mode--count-trailing-open-brackets
-    ((counter kotlin-mode--bracket-counter))
+(defun kotlin-mode--count-trailing-open-brackets (counter)
   "If the bracket count is at zero, and there are open-brackets at the end
    of the line, do not count them, but add a single indentation level."
   (if (= (oref counter count) 0)
@@ -440,19 +437,16 @@
              (kotlin-mode--add-indent counter kotlin-tab-width)
              (oset counter use-base nil)))))
 
-(cl-defmethod kotlin-mode--add-count
-  ((counter kotlin-mode--bracket-counter) val)
+(defun kotlin-mode--add-count (counter val)
   (cl-incf (oref counter count) val))
 
-(cl-defmethod kotlin-mode--subtract-count
-  ((counter kotlin-mode--bracket-counter) val)
+(defun kotlin-mode--subtract-count (counter val)
   (cl-decf (oref counter count) val))
 
-(cl-defmethod kotlin-mode--add-indent
-  ((counter kotlin-mode--bracket-counter) val)
+(defun kotlin-mode--add-indent (counter val)
   (cl-incf (oref counter indent) val))
 
-(cl-defmethod kotlin-mode--finished ((counter kotlin-mode--bracket-counter))
+(defun kotlin-mode--finished (counter)
   (oref counter finished))
 
 (defun kotlin-mode--in-comment-block ()
@@ -484,7 +478,7 @@
       (kotlin-mode--beginning-of-buffer-indent)
     (let ((cur-indent 0))
       ;; Find bracket-based indentation first
-      (let ((bracket-counter (kotlin-mode--bracket-counter)))
+      (let ((bracket-counter (make-instance 'kotlin-mode--bracket-counter)))
         (save-excursion
           (skip-syntax-forward "-")
           (kotlin-mode--count-leading-close-brackets bracket-counter))

--- a/test/kotlin-mode-test.el
+++ b/test/kotlin-mode-test.el
@@ -9,7 +9,7 @@ import foo.Bar
 import bar.Bar as bBar
 "))
       (insert text)
-      (beginning-of-buffer)
+      (goto-char (point-min))
       (kotlin-mode)
       (setq-local indent-tabs-mode nil)
       (setq-local tab-width 4)
@@ -19,19 +19,19 @@ import bar.Bar as bBar
 
       (should (equal text (buffer-string)))
 
-      (next-line)
+      (forward-line)
       (kotlin-mode--indent-line)
       (should (equal text (buffer-string)))
 
-      (next-line)
+      (forward-line)
       (kotlin-mode--indent-line)
       (should (equal text (buffer-string)))
 
-      (next-line)
+      (forward-line)
       (kotlin-mode--indent-line)
       (should (equal text (buffer-string)))
 
-      (next-line)
+      (forward-line)
       (kotlin-mode--indent-line)
       (should (equal text (buffer-string))))))
 
@@ -42,12 +42,12 @@ return a + b
 }"))
 
       (insert text)
-      (beginning-of-buffer)
+      (goto-char (point-min))
       (kotlin-mode)
       (setq-local indent-tabs-mode nil)
       (setq-local tab-width 4)
       (setq-local kotlin-tab-width 4)
-      (next-line)
+      (forward-line)
 
       (kotlin-mode--indent-line)
       (should (equal (buffer-string) "fun sum(a: Int, b: Int): Int {
@@ -62,7 +62,7 @@ return a + b
 .forEach { print(it) }"))
 
       (insert text)
-      (beginning-of-buffer)
+      (goto-char (point-min))
       (kotlin-mode)
       (setq-local indent-tabs-mode nil)
       (setq-local tab-width 4)
@@ -70,13 +70,13 @@ return a + b
 
       (kotlin-mode--indent-line)
 
-      (next-line)
+      (forward-line)
       (kotlin-mode--indent-line)
 
-      (next-line)
+      (forward-line)
       (kotlin-mode--indent-line)
 
-      (next-line)
+      (forward-line)
       (kotlin-mode--indent-line)
 
       (should (equal (buffer-string) "names.filter { it.empty }
@@ -93,7 +93,7 @@ return a + b
 (ert-deftest kotlin-mode--sample-test ()
   (with-temp-buffer
     (insert-file-contents "test/sample.kt")
-    (beginning-of-buffer)
+    (goto-char (point-min))
     (kotlin-mode)
     (setq-local indent-tabs-mode nil)
     (setq-local tab-width 4)

--- a/test/kotlin-mode-test.el
+++ b/test/kotlin-mode-test.el
@@ -117,6 +117,35 @@ return a + b
       (kotlin-mode--indent-line)
       (should (equal text (buffer-string))))))
 
+(ert-deftest kotlin-mode--indent-comment-at-bob--test ()
+  (with-temp-buffer
+    (let ((text "/*
+ *
+ *
+ */"))
+      (pop-to-buffer (current-buffer))
+      (insert text)
+      (goto-char (point-min))
+      (kotlin-mode)
+      (setq-local indent-tabs-mode nil)
+      (setq-local tab-width 4)
+      (setq-local kotlin-tab-width 4)
+
+      (kotlin-mode--indent-line)
+      (should (equal text (buffer-string)))
+
+      (forward-line)
+      (kotlin-mode--indent-line)
+      (should (equal text (buffer-string)))
+
+      (forward-line)
+      (kotlin-mode--indent-line)
+      (should (equal text (buffer-string)))
+
+      (forward-line)
+      (kotlin-mode--indent-line)
+      (should (equal text (buffer-string))))))
+
 (defun next-non-empty-line ()
   "Moves to the next non-empty line"
   (forward-line)

--- a/test/kotlin-mode-test.el
+++ b/test/kotlin-mode-test.el
@@ -16,7 +16,6 @@ import bar.Bar as bBar
       (setq-local kotlin-tab-width 4)
 
       (kotlin-mode--indent-line)
-
       (should (equal text (buffer-string)))
 
       (forward-line)
@@ -83,6 +82,40 @@ return a + b
     .sortedBy { it }
     .map { it.toUpperCase() }
     .forEach { print(it) }")))))
+
+(ert-deftest kotlin-mode--ignore-comment-test ()
+  (with-temp-buffer
+    (let ((text "fun foo {
+    bar()
+    // }
+    bar()
+}"))
+      (pop-to-buffer (current-buffer))
+      (insert text)
+      (goto-char (point-min))
+      (kotlin-mode)
+      (setq-local indent-tabs-mode nil)
+      (setq-local tab-width 4)
+      (setq-local kotlin-tab-width 4)
+
+      (kotlin-mode--indent-line)
+      (should (equal text (buffer-string)))
+
+      (forward-line)
+      (kotlin-mode--indent-line)
+      (should (equal text (buffer-string)))
+
+      (forward-line)
+      (kotlin-mode--indent-line)
+      (should (equal text (buffer-string)))
+
+      (forward-line)
+      (kotlin-mode--indent-line)
+      (should (equal text (buffer-string)))
+
+      (forward-line)
+      (kotlin-mode--indent-line)
+      (should (equal text (buffer-string))))))
 
 (defun next-non-empty-line ()
   "Moves to the next non-empty line"

--- a/test/kotlin-mode-test.el
+++ b/test/kotlin-mode-test.el
@@ -1,7 +1,3 @@
-;; Tests assume a tab is represented by 4 spaces
-(setq-default indent-tabs-mode nil)
-(setq-default tab-width 4)
-
 (require 'kotlin-mode)
 
 (ert-deftest kotlin-mode--top-level-indent-test ()
@@ -14,6 +10,11 @@ import bar.Bar as bBar
 "))
       (insert text)
       (beginning-of-buffer)
+      (kotlin-mode)
+      (setq-local indent-tabs-mode nil)
+      (setq-local tab-width 4)
+      (setq-local kotlin-tab-width 4)
+
       (kotlin-mode--indent-line)
 
       (should (equal text (buffer-string)))
@@ -42,6 +43,10 @@ return a + b
 
       (insert text)
       (beginning-of-buffer)
+      (kotlin-mode)
+      (setq-local indent-tabs-mode nil)
+      (setq-local tab-width 4)
+      (setq-local kotlin-tab-width 4)
       (next-line)
 
       (kotlin-mode--indent-line)
@@ -58,6 +63,10 @@ return a + b
 
       (insert text)
       (beginning-of-buffer)
+      (kotlin-mode)
+      (setq-local indent-tabs-mode nil)
+      (setq-local tab-width 4)
+      (setq-local kotlin-tab-width 4)
 
       (kotlin-mode--indent-line)
 
@@ -83,24 +92,24 @@ return a + b
 
 (ert-deftest kotlin-mode--sample-test ()
   (with-temp-buffer
-      (insert-file-contents "test/sample.kt")
-      (beginning-of-buffer)
-      (while (not (eobp))
-        (let ((expected-line (thing-at-point 'line)))
+    (insert-file-contents "test/sample.kt")
+    (beginning-of-buffer)
+    (kotlin-mode)
+    (setq-local indent-tabs-mode nil)
+    (setq-local tab-width 4)
+    (setq-local kotlin-tab-width 4)
+    (while (not (eobp))
+      (let ((expected-line (thing-at-point 'line)))
 
-          ;; Remove existing indentation
-          (beginning-of-line)
-          (delete-region (point) (progn (skip-chars-forward " \t") (point)))
+        ;; Remove existing indentation
+        (beginning-of-line)
+        (delete-region (point) (progn (skip-chars-forward " \t") (point)))
 
-          ;; Indent the line
-          (kotlin-mode--indent-line)
+        ;; Indent the line
+        (kotlin-mode--indent-line)
 
-          ;; Check that the correct indentation is re-applied
-          (should (equal expected-line (thing-at-point 'line)))
+        ;; Check that the correct indentation is re-applied
+        (should (equal expected-line (thing-at-point 'line)))
 
-          ;; Go to the next non-empty line
-          (next-non-empty-line)
-          )
-        )
-      )
-  )
+        ;; Go to the next non-empty line
+        (next-non-empty-line)))))


### PR DESCRIPTION
Examples:

```kotlin
fun foo {
    bar()
    // }
    bar() // indenting here
}
```

At the beginning of buffer:

```kotlin
/*
 * aaa
 * bbb
 * ccc
 */
```

This PR also refactor of indentation logic.

This PR contains commits of #49.