### PR TITLE
Make underscore and at sign as a part of a symbol

### DIFF
--- a/kotlin-mode.el
+++ b/kotlin-mode.el
@@ -143,8 +143,9 @@
     (modify-syntax-entry ?\' "\"" st)
     (modify-syntax-entry ?` "\"" st)
 
-    ;; `_' as being a valid part of a word
-    (modify-syntax-entry ?_ "w" st)
+    ;; `_' and `@' as being a valid part of a symbol
+    (modify-syntax-entry ?_ "_" st)
+    (modify-syntax-entry ?@ "_" st)
 
     ;; b-style comment
     (modify-syntax-entry ?/ ". 124b" st)
@@ -259,7 +260,7 @@
     (,(rx-to-string
        `(and bow (or ,@kotlin-mode--val-decl-keywords) eow
              (+ space)
-             (group (+ word)) (* space)  (\? ":"))
+             (group (+ (or word (syntax symbol)))) (* space)  (\? ":"))
        t)
      1 font-lock-variable-name-face t)
 


### PR DESCRIPTION
`_` and `@` should be a part of a symbol rather than a word.

- `C-M-f` (`forward-sexp`) and `C-M-b` (`backward-sexp`) skip those characters.

- `M-f` (`forward-word`) and `M-b` (`backward-word`) stop at those characters, like `java-mode`.
  Use `superword-mode` to restore original behaviour.
  Fixes https://github.com/Emacs-Kotlin-Mode-Maintainers/kotlin-mode/issues/59.