### PR TITLE
Fix indentation for if/else and getters/setters with visibility modifiers

### DIFF
--- a/kotlin-mode.el
+++ b/kotlin-mode.el
@@ -335,6 +335,18 @@
         (while (and (looking-at "^[ \t]*$") (not (bobp)))
           (forward-line -1)))))
 
+(defun kotlin-mode--prev-line-begins (pattern)
+  "Return whether the previous line begins with the given pattern"
+  (save-excursion
+    (kotlin-mode--prev-line)
+    (looking-at (format "^[ \t]*%s" pattern))))
+
+(defun kotlin-mode--prev-line-ends (pattern)
+  "Return whether the previous line ends with the given pattern"
+  (save-excursion
+    (kotlin-mode--prev-line)
+    (looking-at (format ".*%s[ \t]*$" pattern))))
+
 (defun kotlin-mode--line-begins (pattern)
   "Return whether the current line begins with the given pattern"
   (save-excursion
@@ -356,10 +368,13 @@
 (defun kotlin-mode--line-continuation()
   "Return whether this line continues a statement in the previous line"
   (or
-   (kotlin-mode--line-begins "\\([.=:]\\|->\\|[sg]et\\b\\)")
-   (save-excursion
-     (kotlin-mode--prev-line)
-     (kotlin-mode--line-ends "\\([=:]\\|->\\)"))))
+   (and (kotlin-mode--prev-line-begins "\\(if\\|else\\)[ \t]*")
+        (not (kotlin-mode--prev-line-ends "{.*")))
+   (or
+    (kotlin-mode--line-begins "\\([.=:]\\|->\\|\\(\\(private\\|public\\|protected\\|internal\\)[ \t]*\\)?[sg]et\\b\\)")
+    (save-excursion
+      (kotlin-mode--prev-line)
+      (kotlin-mode--line-ends "\\([=:]\\|->\\)")))))
 
 (defun kotlin-mode--base-indentation ()
   "Return the indentation level of the current line based on brackets only,


### PR DESCRIPTION
This fixes the issue with indentation for if/else statements without brackets:

```
// Previous behavior
if (condition1)
// Do stuff
else if (condition2)
// Do stuff
else
// Do stuff

// New behavior
if (condition1)
     // Do stuff
else if (condition2)
     // Do stuff
else
     // Do stuff
```

It also fixes indentation for getters and setters with visibility modifiers:
```
// Previous behavior
var property1 = x
    set

var property2 = y
private set

// New behavior
var property1 = x
    set

var property2 = y
    private set
```

This is _not_ a rewrite of the indentation system. It is simply a slight alteration to fix behavior in the current system.