### PR TITLE
Properly indent 2-line for and while loops without brackets

### DIFF
--- a/kotlin-mode.el
+++ b/kotlin-mode.el
@@ -368,7 +368,7 @@
 (defun kotlin-mode--line-continuation()
   "Return whether this line continues a statement in the previous line"
   (or
-   (and (kotlin-mode--prev-line-begins "\\(if\\|else\\)[ \t]*")
+   (and (kotlin-mode--prev-line-begins "\\(if\\|else\\|for\\|while\\)[ \t]*")
         (not (kotlin-mode--prev-line-ends "{.*")))
    (or
     (kotlin-mode--line-begins "\\([.=:]\\|->\\|\\(\\(private\\|public\\|protected\\|internal\\)[ \t]*\\)?[sg]et\\b\\)")


### PR DESCRIPTION
Indentation for `for` and `while` loops should behave similar to `if`/`else`. This is a fix to make the behavior consistent.

```
// Previous behavior
while (condition)
doSomething()

for (item in list)
doSomething()

// New behavior
while (condition)
    doSomething()

for (item in list)
    doSomething()
```

I apologize for missing these cases in the PR I submitted yesterday.