### PR TITLE
Add `beginning of defun` and `end of defun` functions

### DIFF
--- a/kotlin-mode-lexer.el
+++ b/kotlin-mode-lexer.el
@@ -588,7 +588,7 @@ expression as a token with one of the following types:
           kotlin-mode--parameter-modifier-keywords
           kotlin-mode--function-modifier-keywords))
 
-(defconst kotlin-beginning-of-defun-re
+(defconst kotlin-mode--beginning-of-defun-re
   (concat
    "\\s-*"
    (regexp-opt kotlin-mode--modifier-keywords)
@@ -2499,7 +2499,12 @@ Assuming the point is on a string."
   "Move backward to the beginning of the current defun.
 With ARG, move backward multiple defuns.  Negative ARG means
 move forward."
-  (when (re-search-backward kotlin-beginning-of-defun-re nil t (or arg 1))
+  (beginning-of-line)
+  ;; If currently looking at an annotation, go its function's beginning.
+  (if (looking-at "\\s-*@")
+      (re-search-forward kotlin-mode--beginning-of-defun-re nil t 1)
+    (if (< arg 0) (+ arg 1) (- arg 1)))
+  (when (re-search-backward kotlin-mode--beginning-of-defun-re nil t (or arg 1))
     (beginning-of-line)
     t))
 
@@ -2509,7 +2514,7 @@ move forward."
   ;; If currently looking at an annotation, go to its function's beginning.
   (if (looking-at "\\s-*@")
       (kotlin-mode--beginning-of-defun -1))
-  (while (not (looking-at kotlin-beginning-of-defun-re))
+  (while (not (looking-at kotlin-mode--beginning-of-defun-re))
     (forward-line -1)
     (beginning-of-line))
   (if (< (save-excursion (re-search-forward "{"))

--- a/kotlin-mode-lexer.el
+++ b/kotlin-mode-lexer.el
@@ -588,6 +588,12 @@ expression as a token with one of the following types:
           kotlin-mode--parameter-modifier-keywords
           kotlin-mode--function-modifier-keywords))
 
+(defconst kotlin-beginning-of-defun-re
+  (concat
+   "\\s-*"
+   (regexp-opt kotlin-mode--modifier-keywords)
+   "*\\s-*\\_<fun\\_>"))
+
 (defun kotlin-mode--implicit-semi-p ()
   "Return non-nil if the point is after the end of a statement."
   (let ((previous-token (save-excursion
@@ -2488,6 +2494,36 @@ Assuming the point is on a string."
       (goto-char matching-bracket)
       (kotlin-mode--forward-string-chunk)))
   (point))
+
+(defun kotlin-mode--beginning-of-defun (&optional arg)
+  "Move backward to the beginning of the current defun.
+With ARG, move backward multiple defuns.  Negative ARG means
+move forward."
+  (when (re-search-backward kotlin-beginning-of-defun-re nil t (or arg 1))
+    (beginning-of-line)
+    t))
+
+(defun kotlin-mode--end-of-defun ()
+  "Move forward to the end of the current defun."
+  (beginning-of-line)
+  ;; If currently looking at an annotation, go to its function's beginning.
+  (if (looking-at "\\s-*@")
+      (kotlin-mode--beginning-of-defun -1))
+  (while (not (looking-at kotlin-beginning-of-defun-re))
+    (forward-line -1)
+    (beginning-of-line))
+  (if (< (save-excursion (re-search-forward "{"))
+         (save-excursion (re-search-forward "=")))
+      (progn
+        (re-search-forward "{")
+        (backward-char)
+        (condition-case nil
+            (forward-sexp)
+          (scan-error (goto-char (point-max)))))
+    ;; Single expression function
+    (re-search-forward "=")
+    (forward-paragraph)
+    (backward-char)))
 
 (defun kotlin-mode--goto-non-comment-bol ()
   "Back to the beginning of line that is not inside a comment."

--- a/kotlin-mode.el
+++ b/kotlin-mode.el
@@ -383,6 +383,9 @@ and return non-nil.  Return nil otherwise."
 
   (delete-overlay kotlin-mode--anchor-overlay)
 
+  (setq-local beginning-of-defun-function #'kotlin-mode--beginning-of-defun)
+  (setq-local end-of-defun-function #'kotlin-mode--end-of-defun)
+
   :group 'kotlin
   :syntax-table kotlin-mode-syntax-table)
 


### PR DESCRIPTION
This resolves #79 

Implemented `beginning-of-defun` and `end-of-defun` functions.

## Example
Taking the following function as an example.
```kotlin
@Get("/foo")
suspend fun foo(): HttpResponse {
    log.info("My name is ${coroutineContext[CoroutineName]?.name}")
    return HttpResponse.of("OK")
}
```

The cursor moves the point expressed as `*`.
### Beginning of defun
```kotlin
@Get("/foo")
*suspend fun foo(): HttpResponse {
    log.info("My name is ${coroutineContext[CoroutineName]?.name}")
    return HttpResponse.of("OK")
}
```

### End of defun
```kotlin
@Get("/foo")
suspend fun foo(): HttpResponse {
    log.info("My name is ${coroutineContext[CoroutineName]?.name}")
    return HttpResponse.of("OK")
}
*
```
`end-of-defun` function works as same as other language modes do.
